### PR TITLE
Bug: Name from feed is not added to error and attempt stats

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -63,18 +63,23 @@ function isCriticalError(err) {
   return true;
 }
 
+function getStatsName(clientName, feedName) {
+    if (feedName) {
+        return clientName + '.' + feedName;
+    }
+
+    return clientName;
+}
+
 Client.prototype._log = function (res) {
   if (this.logger) {
     this.logger.info(res.request.method, res.request.href, res.statusCode, res.elapsedTime, 'ms');
   }
 };
 
-Client.prototype._recordStats = function (res, name) {
+Client.prototype._recordStats = function (res, feedName) {
   if (this.stats) {
-    var prefix = this.name;
-    if (name) {
-      prefix += '.' + name;
-    }
+    var prefix = getStatsName(this.name, feedName);
 
     this.stats.increment(prefix + '.requests');
     this.stats.increment(prefix + '.responses.' + res.statusCode);
@@ -93,7 +98,10 @@ Client.prototype._request = function (method, url, opts, cb) {
 
   request[method](url, opts, function (err, res, body) {
     if (err) {
-      if (client.stats) client.stats.increment(client.name + '.request_errors');
+      if (client.stats) {
+        var statsName = getStatsName(client.name, opts.name);
+        client.stats.increment(statsName + '.request_errors');
+      }
       err = new Error(util.format('Request failed for %s %s', url, err.message));
       return cb(err);
     }
@@ -138,7 +146,8 @@ Client.prototype._requestWithRetries = function (method, url, opts, cb) {
       }
 
       if (client.stats) {
-        client.stats.timing(client.name + '.attempts', currentAttempts);
+        var statsName = getStatsName(client.name, opts.name);
+        client.stats.timing(statsName + '.attempts', currentAttempts);
       }
 
       cb(err, body, res);

--- a/test/client.js
+++ b/test/client.js
@@ -140,7 +140,7 @@ describe('Rest Client', function () {
       });
     });
 
-    it('increments a request counter counter with the name of the client and feed if provided', function (done) {
+    it('increments a request counter with the name of the client and feed if provided', function (done) {
       var client = Client.createClient({
         name: 'my_client',
         stats: stats
@@ -176,6 +176,22 @@ describe('Rest Client', function () {
       client.get(url, function (err) {
         assert(err);
         sinon.assert.calledWith(stats.increment, 'http.request_errors');
+        done();
+      });
+    });
+
+    it('increments a counter for errors with feed name in it', function (done) {
+      var client = Client.createClient({
+        name: 'my_client',
+        stats: stats
+      });
+      nock.cleanAll();
+
+      client.get(url, {
+        name: 'feed'
+      }, function (err) {
+        assert(err);
+        sinon.assert.calledWith(stats.increment, 'my_client.feed.request_errors');
         done();
       });
     });
@@ -253,6 +269,23 @@ describe('Rest Client', function () {
       client.get(url, function (err) {
         assert.ifError(err);
         sinon.assert.calledWith(stats.timing, 'http.attempts', 2);
+        done();
+      });
+    });
+
+    it('records a timer for the number of attempts to a specific feed timer', function (done) {
+      nockRetries(1);
+      client = Client.createClient({
+        name: 'my_client',
+        stats: stats,
+        retries: 1,
+        retryTimeout: 0
+      });
+      client.get(url, {
+          name: 'feed'
+      }, function (err) {
+        assert.ifError(err);
+        sinon.assert.calledWith(stats.timing, 'my_client.feed.attempts', 2);
         done();
       });
     });


### PR DESCRIPTION
When a user gets either a failed request or an attempted request they should get stats on a per feed basis to reflect that these attempts failed on a particular feed.