### PR TITLE
Make HTTP errors cacheable

### DIFF
--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -71,15 +71,29 @@ CachingClient.prototype.get = function (url, opts, cb) {
   var doNotVary = this.doNotVary;
 
   this._getCachedOrFetch(url, opts, function (err, body, res) {
-    if (err) return cb(err);
+    var cachedObject;
+    var maxAge;
 
     if (res && isCacheable(res)) {
-      cache.set(createKeyObject(url, opts, doNotVary), {
-        body: body
-      }, getMaxAge(res), client._handleCacheError.bind(client));
+      maxAge = getMaxAge(res);
+      cachedObject = {};
+
+      if (body) {
+        cachedObject.body = body;
+      }
+
+      if (err && err.statusCode) {
+        cachedObject.error = {
+          message: err.message,
+          statusCode: err.statusCode,
+          body: err.body
+        }
+      };
+
+      cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, client._handleCacheError.bind(client));
     }
 
-    cb(null, body);
+    cb(err, body);
   });
 };
 
@@ -92,12 +106,20 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   cache.get(createKeyObject(url, opts, doNotVary), function (err, cached) {
     if (err) client._handleCacheError(err);
 
-    var cacheHit = cached && cached.item && cached.item.body;
+    var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
+    var cachedError;
 
     if (cacheHit) {
       if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.hits');
 
-      return cb(null, cached.item.body);
+      if (cached.item.error) {
+        cachedError = cached.item.error;
+        err = new Error(cachedError.message);
+        err.statusCode = cachedError.statusCode;
+        err.body = cachedError.body;
+      }
+
+      return cb(err, cached.item.body);
     }
 
     if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -74,8 +74,11 @@ CachingClient.prototype.get = function (url, opts, cb) {
     if (err) return cb(err);
 
     if (res && isCacheable(res)) {
-      cache.set(createKeyObject(url, opts, doNotVary), body, getMaxAge(res), client._handleCacheError.bind(client));
+      cache.set(createKeyObject(url, opts, doNotVary), {
+        body: body
+      }, getMaxAge(res), client._handleCacheError.bind(client));
     }
+
     cb(null, body);
   });
 };
@@ -89,14 +92,17 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   cache.get(createKeyObject(url, opts, doNotVary), function (err, cached) {
     if (err) client._handleCacheError(err);
 
-    if (!cached) {
-      if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
-      delegate.getWithResponse(url, opts, cb);
+    var cacheHit = cached && cached.item && cached.item.body;
 
-    } else {
+    if (cacheHit) {
       if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.hits');
-      cb(null, cached.item);
+
+      return cb(null, cached.item.body);
     }
+
+    if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
+
+    delegate.getWithResponse(url, opts, cb);
   });
 };
 

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -56,7 +56,7 @@ function createKeyObject(url, opts, doNotVary) {
 
   return {
     id: id,
-    segment: 'rest_client:' + version
+    segment: 'flashheart:' + version
   };
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -119,7 +119,7 @@ Client.prototype._request = function (method, url, opts, cb) {
       err.statusCode = res.statusCode;
       err.body = body;
 
-      return cb(err);
+      return cb(err, res);
     }
 
     cb(null, res, body);

--- a/test/caching.js
+++ b/test/caching.js
@@ -23,7 +23,7 @@ describe('Caching', function () {
   };
 
   var expectedKey = {
-    segment: 'rest_client:' + require('../package').version,
+    segment: 'flashheart:' + require('../package').version,
     id: url
   };
 
@@ -196,7 +196,7 @@ describe('Caching', function () {
     };
 
     var keyWithOpts = {
-      segment: 'rest_client:' + require('../package').version,
+      segment: 'flashheart:' + require('../package').version,
       id: url + JSON.stringify(opts)
     };
 


### PR DESCRIPTION
* HTTP errors (404, 500 etc.) are now cached as indicated by the `cache-control` header
* This relies on a change to our underlying cache data format
* We no longer just store the body in the cache
* We now store an object with either a `body` property or an `error` property
* The `error` property contains everything we need to recreate an `Error` object when we pull it out of the cache
* `err.message`, `err.statusCode`, `err.body`
* The above is required as we can't just JSON stringify `Error` objects

A valid response is cached as:

```json
{
  "body": {
    "foo": "bar"
  }
}
```

A HTTP error is cached as:

```json
{
  "error": {
    "message": "An error occurred",
    "statusCode": 503,
    "body": {
      "oh": "no!"
    }
  }
}
```