### PR TITLE
Feature: Allows setting/overriding of the existing request clients de…

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ const client = require('flashheart').createClient({
 });
 ```
 
+Alternatively, you can override or append to the default `request` options.
+
+```js
+const client = require('flashheart').createClient({
+  defaults: {
+    json: false,
+    headers: {
+      'X-Api-Key': 'foo'
+    }
+  }
+});
+```
+
 #### Usage with client certificates
 
 The `request` option can also be used to pass a pre-configured request client for HTTPS client certificate authentication:
@@ -226,6 +239,7 @@ Creates a new client.
 * `circuitBreakerResetTimeout` - _optional_ - Time in milliseconds to wait before the circuit breaker resets after opening (_default 10000_)
 * `userAgent` - _optional_ - A custom user agent for the client (_default flashheart/VERSION_)
 * `doNotVary` - _optional_ - An array of headers to ignore when creating cache keys (_default_ `[]`)
+* `defaults` - _optional_ - A [`request`](https://github.com/request/request) options object to append or override existing default options
 * `request` - _optional_ - A pre-configured instance of [`request`](https://github.com/request/request)
 
 ### `client.get`

--- a/lib/client.js
+++ b/lib/client.js
@@ -40,6 +40,10 @@ function Client(opts) {
   this.retryTimeout = _.isUndefined(opts.retryTimeout) ? DEFAULT_RETRY_TIMEOUT : opts.retryTimeout;
   this.userAgent = _.isUndefined(opts.userAgent) ? util.format('%s/%s', package.name, package.version) : opts.userAgent;
 
+  if (opts.defaults) {
+    this.request = this.request.defaults(opts.defaults);
+  }
+
   var circuitBreakerOptions = _.defaults({
     maxFailures: opts.circuitBreakerMaxFailures,
     resetTimeout: opts.circuitBreakerResetTimeout

--- a/test/client.js
+++ b/test/client.js
@@ -58,6 +58,34 @@ describe('Rest Client', function () {
     assert.ok(client);
   });
 
+  it('can append default options to the existing request client', function (done) {
+    var client = Client.createClient({
+      defaults: {
+        baseUrl: host
+      }
+    });
+
+    client.get(path, function (err) {
+      assert.ifError(err);
+      assert.strictEqual(nock.isDone(), true);
+      done();
+    });
+  });
+
+  it('can override default options on the existing request client', function (done) {
+    var client = Client.createClient({
+      defaults: {
+        time: false
+      }
+    });
+
+    client.get(url, function (err, body, res) {
+      assert.ifError(err);
+      assert.strictEqual(res.elapsedTime, undefined);
+      done();
+    });
+  });
+
   describe('.get', function () {
     it('returns body of a JSON response', function (done) {
       client.get(url, function (err, body) {


### PR DESCRIPTION
Currently the recommended way to set default options for `request` is to provide flashheart a newly created instance of it.

This PR aims to allow you to pass in a `defaults` object on client creation without having to create a new instance of `request`. This will either append new default options to the internal request instance, or override options that are already defined. More info on how `request` deals with defaults [here](https://github.com/request/request#requestdefaultsoptions).