### PR TITLE
Fix: Don't create a new request object for each request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -103,14 +103,15 @@ Client.prototype._recordStats = function (res, feedName) {
 
 Client.prototype._request = function (method, url, opts, cb) {
   var client = this;
-  var request = this.request.defaults({
+
+  opts = _.merge({
     timeout: this.timeout,
     headers: {
       'User-Agent': this.userAgent
     }
-  });
+  }, opts);
 
-  request[method](url, opts, function (err, requestRes, body) {
+  this.request[method](url, opts, function (err, requestRes, body) {
     var statsName;
 
     if (err) {


### PR DESCRIPTION
* Combines the opts for the particular request instead of using `request.defaults`