### PR TITLE
Support for stale-while-revalidate and shared request execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ const client = require('flashheart').createClient({
 });
 ```
 
+The cache behaviour can be enabled to act on stale-while-revalidate headers. When enabled this causes the cache to serve stale but refresh the cache entry in the background. It is enabled with the `swr` option:
+```js
+const client = require('flashheart').createClient({
+  cache: storage,
+  swr: true
+});
+```
+
 ### Logging
 
 All requests can be logged at `info` level if you provide a logger that supports the standard logging API (like `console` or [Winston](https://github.com/flatiron/winston))

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm install --save flashheart
 * [StatsD integration](#stats)
 * [Retries](#retries)
 * [Circuit breaker](#circuit-breaker)
+* [Shared Execution](#shared-execution)
 
 ## Usage
 
@@ -153,6 +154,17 @@ For example to trip after 200 failures and try to reset after 30 seconds:
 const client = require('flashheart').createClient({
   circuitBreakerMaxFailures: 200,
   circuitBreakerResetTimeout: 30000
+});
+```
+### Shared Execution
+
+The client can be configured to share execution of get requests, protecting downstream services from the thundering herd. It can be enabled/disabled by providing a boolean value the `sharedExecution` property. By default this is disabled.
+
+For example to enable shared execution:
+
+```js
+const client = require('flashheart').createClient({
+    sharedExecution: true
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ const client = require('flashheart').createClient({
 ```
 ### Shared Execution
 
-The client can be configured to share execution of get requests, protecting downstream services from the thundering herd. It can be enabled/disabled by providing a boolean value the `sharedExecution` property. By default this is disabled.
+The client can be configured to share execution of HTTP GET requests, protecting downstream services from the thundering herd. It can be enabled/disabled by providing a boolean value for the `sharedExecution` property. By default this is disabled.
 
 For example to enable shared execution:
 

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -111,8 +111,9 @@ CachingClient.prototype._cacheResponse = function (cacheKey, err, body, res){
                 body: err.body
             };
         }
-        if (staleWhileRevalidate > 0){
-            cachedObject.revalidateTimestamp = new Date().getTime() + staleWhileRevalidate;
+        if (client.swrEnabled && staleWhileRevalidate > 0){
+            cachedObject.revalidateTimestamp = new Date().getTime() + maxAge;
+            maxAge = maxAge + staleWhileRevalidate;
         }
 
         cache.set(cacheKey, cachedObject, maxAge, client._handleCacheError.bind(client));

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -6,9 +6,6 @@ function CachingClient(delegate, opts) {
   this.delegate = delegate;
   this.cache = opts.cache;
   this.doNotVary = opts.doNotVary || [];
-  if (opts.sharedExecution !== undefined && opts.sharedExecution === true){
-      this.sharedExecutionCallbacks = {};
-  }
 }
 
 function isCacheable(res) {
@@ -107,8 +104,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   var cache = this.cache;
   var delegate = this.delegate;
   var doNotVary = this.doNotVary;
-  var cacheKey = createKeyObject(url, opts, doNotVary);
-  cache.get(cacheKey, function (err, cached) {
+  cache.get(createKeyObject(url, opts, doNotVary), function (err, cached) {
     if (err) client._handleCacheError(err);
 
     var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
@@ -129,28 +125,8 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
 
     if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
 
-    client._fetchOrShareExecution(cacheKey.id, url, opts, cb);
+    delegate.getWithResponse(url, opts, cb);
   });
-};
-
-CachingClient.prototype._fetchOrShareExecution = function (fetchKey, url, opts, cb ){
-    var client = this;
-    var delegate = this.delegate;
-    if (!client.sharedExecutionCallbacks){
-        delegate.getWithResponse(url, opts, cb);
-    } else if (!client.sharedExecutionCallbacks[fetchKey]){
-        var handler = function(err, body, res){
-            var cbs = client.sharedExecutionCallbacks[fetchKey];
-            delete client.sharedExecutionCallbacks[fetchKey];
-            for (var i = 0; i < cbs.length; i++){
-                cbs[i](err, body, res, (i !== 0));
-            }
-        };
-        client.sharedExecutionCallbacks[fetchKey] = [ cb ];
-        delegate.getWithResponse(url, opts, handler);
-    } else {
-        client.sharedExecutionCallbacks[fetchKey].push(cb);
-    }
 };
 
 CachingClient.prototype._handleCacheError = function (err) {

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -6,6 +6,7 @@ function CachingClient(delegate, opts) {
   this.delegate = delegate;
   this.cache = opts.cache;
   this.doNotVary = opts.doNotVary || [];
+  this.inflights = {};
 }
 
 function isCacheable(res) {
@@ -104,8 +105,8 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   var cache = this.cache;
   var delegate = this.delegate;
   var doNotVary = this.doNotVary;
-
-  cache.get(createKeyObject(url, opts, doNotVary), function (err, cached) {
+  var cacheKey = createKeyObject(url, opts, doNotVary);
+  cache.get(cacheKey, function (err, cached) {
     if (err) client._handleCacheError(err);
 
     var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
@@ -126,8 +127,26 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
 
     if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
 
-    delegate.getWithResponse(url, opts, cb);
+    client._fetchOrJoinInflight(cacheKey.id, url, opts, cb);
   });
+};
+
+CachingClient.prototype._fetchOrJoinInflight = function (fetchKey, url, opts, cb ){
+    var client = this;
+    var delegate = this.delegate;
+    if (!client.inflights[fetchKey]){
+        var handler = function(err, body, res){
+            var entries = client.inflights[fetchKey];
+            delete client.inflights[fetchKey];
+            for (var i = 0; i < entries.length; i++){
+                entries[i](err, body, res, (i !== 0));
+            }
+        };
+        client.inflights[fetchKey] = [ cb ];
+        delegate.getWithResponse(url, opts, handler);
+    } else {
+        client.inflights[fetchKey].push(cb);
+    }
 };
 
 CachingClient.prototype._handleCacheError = function (err) {

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -7,6 +7,7 @@ function CachingClient(delegate, opts) {
   this.cache = opts.cache;
   this.swrEnabled = _.isUndefined(opts.swr) ? false : opts.swr;  
   this.doNotVary = opts.doNotVary || [];
+  this.refreshes = {};
 }
 
 function isCacheable(res) {
@@ -140,12 +141,20 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
         err.body = cachedError.body;
       }
 
-      if (client.swrEnabled === true && cached.item.revalidateTimestamp !== undefined && cached.item.revalidateTimestamp < new Date().getTime()){
+      if (client.swrEnabled === true &&
+          cached.item.revalidateTimestamp !== undefined &&
+          cached.item.revalidateTimestamp < new Date().getTime() &&
+          !client.refreshes[cacheKey]){
+
+        client.refreshes[cacheKey] = true;
         if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.refresh');
-
-        delegate.getWithResponse(url, opts, _.partial(client._cacheResponse, cacheKey).bind(client));
+        var refreshCache = function(err, body, res){
+          delete client.refreshes[cacheKey];
+          client._cacheResponse(cacheKey, err, body, res);
+        };
+        delegate.getWithResponse(url, opts, refreshCache);
       }
-
+   
       return cb(err, cached.item.body, cached.item.response, true);
     }
 

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -5,6 +5,7 @@ var version = require('../package').version;
 function CachingClient(delegate, opts) {
   this.delegate = delegate;
   this.cache = opts.cache;
+  this.swrEnabled = _.isUndefined(opts.swr) ? false : opts.swr;  
   this.doNotVary = opts.doNotVary || [];
 }
 
@@ -27,6 +28,17 @@ function getMaxAge(res) {
   }
 
   return maxAge;
+}
+
+function getStaleWhileRevalidate(res) {
+  var swr = 0;
+  var cacheControl = getCacheControl(res);
+
+  if (cacheControl) {
+    swr = (cacheControl['stale-while-revalidate'] || 0) * 1000;
+  }
+
+  return swr;
 }
 
 function getCacheControl(res) {
@@ -67,36 +79,43 @@ CachingClient.prototype.get = function (url, opts, cb) {
   }
 
   var client = this;
-  var cache = this.cache;
   var doNotVary = this.doNotVary;
-
+  var cacheKey = createKeyObject(url, opts, doNotVary);
   this._getCachedOrFetch(url, opts, function (err, body, res, servedFromCache) {
-    var cachedObject;
-    var maxAge;
-
-    if (!servedFromCache && res && isCacheable(res)) {
-      maxAge = getMaxAge(res);
-      cachedObject = {};
-
-      if (body) {
-        cachedObject.body = body;
+      if (!servedFromCache){
+          client._cacheResponse(cacheKey, err, body, res);
       }
-
-      cachedObject.response = res;
-
-      if (err && err.statusCode) {
-        cachedObject.error = {
-          message: err.message,
-          statusCode: err.statusCode,
-          body: err.body
-        };
-      }
-
-      cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, client._handleCacheError.bind(client));
-    }
-
-    cb(err, body, res);
+      cb(err, body, res);
   });
+};
+
+CachingClient.prototype._cacheResponse = function (cacheKey, err, body, res){
+    var cache = this.cache;
+    var client = this;
+    if (res && isCacheable(res)){
+        var maxAge = getMaxAge(res);
+        var staleWhileRevalidate = getStaleWhileRevalidate(res);
+        var cachedObject = {};
+
+        if (body) {
+            cachedObject.body = body;
+        }
+        
+        cachedObject.response = res;
+
+        if (err && err.statusCode) {
+            cachedObject.error = {
+                message: err.message,
+                statusCode: err.statusCode,
+                body: err.body
+            };
+        }
+        if (staleWhileRevalidate > 0){
+            cachedObject.revalidateTimestamp = new Date().getTime() + staleWhileRevalidate;
+        }
+
+        cache.set(cacheKey, cachedObject, maxAge, client._handleCacheError.bind(client));
+    }
 };
 
 CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
@@ -104,7 +123,8 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   var cache = this.cache;
   var delegate = this.delegate;
   var doNotVary = this.doNotVary;
-  cache.get(createKeyObject(url, opts, doNotVary), function (err, cached) {
+  var cacheKey = createKeyObject(url, opts, doNotVary);
+  cache.get(cacheKey, function (err, cached) {
     if (err) client._handleCacheError(err);
 
     var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
@@ -118,6 +138,12 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
         err = new Error(cachedError.message);
         err.statusCode = cachedError.statusCode;
         err.body = cachedError.body;
+      }
+
+      if (client.swrEnabled === true && cached.item.revalidateTimestamp !== undefined && cached.item.revalidateTimestamp < new Date().getTime()){
+        if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.refresh');
+
+        delegate.getWithResponse(url, opts, _.partial(client._cacheResponse, cacheKey).bind(client));
       }
 
       return cb(err, cached.item.body, cached.item.response, true);

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -6,7 +6,9 @@ function CachingClient(delegate, opts) {
   this.delegate = delegate;
   this.cache = opts.cache;
   this.doNotVary = opts.doNotVary || [];
-  this.inflights = {};
+  if (opts.sharedExecution !== undefined && opts.sharedExecution === true){
+      this.sharedExecutionCallbacks = {};
+  }
 }
 
 function isCacheable(res) {
@@ -127,25 +129,27 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
 
     if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
 
-    client._fetchOrJoinInflight(cacheKey.id, url, opts, cb);
+    client._fetchOrShareExecution(cacheKey.id, url, opts, cb);
   });
 };
 
-CachingClient.prototype._fetchOrJoinInflight = function (fetchKey, url, opts, cb ){
+CachingClient.prototype._fetchOrShareExecution = function (fetchKey, url, opts, cb ){
     var client = this;
     var delegate = this.delegate;
-    if (!client.inflights[fetchKey]){
+    if (!client.sharedExecutionCallbacks){
+        delegate.getWithResponse(url, opts, cb);
+    } else if (!client.sharedExecutionCallbacks[fetchKey]){
         var handler = function(err, body, res){
-            var entries = client.inflights[fetchKey];
-            delete client.inflights[fetchKey];
-            for (var i = 0; i < entries.length; i++){
-                entries[i](err, body, res, (i !== 0));
+            var cbs = client.sharedExecutionCallbacks[fetchKey];
+            delete client.sharedExecutionCallbacks[fetchKey];
+            for (var i = 0; i < cbs.length; i++){
+                cbs[i](err, body, res, (i !== 0));
             }
         };
-        client.inflights[fetchKey] = [ cb ];
+        client.sharedExecutionCallbacks[fetchKey] = [ cb ];
         delegate.getWithResponse(url, opts, handler);
     } else {
-        client.inflights[fetchKey].push(cb);
+        client.sharedExecutionCallbacks[fetchKey].push(cb);
     }
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -40,6 +40,7 @@ function Client(opts) {
   this.retries = _.isUndefined(opts.retries) ? DEFAULT_RETRIES : opts.retries;
   this.retryTimeout = _.isUndefined(opts.retryTimeout) ? DEFAULT_RETRY_TIMEOUT : opts.retryTimeout;
   this.userAgent = _.isUndefined(opts.userAgent) ? util.format('%s/%s', package.name, package.version) : opts.userAgent;
+  this.sharedExecutionCallbacks = (_.isUndefined(opts.sharedExecution) || opts.sharedExecution === false) ? undefined : {};
 
   if (opts.defaults) {
     this.request = this.request.defaults(opts.defaults);
@@ -83,6 +84,15 @@ function buildResponse(requestRes) {
     headers: requestRes.headers,
     elapsedTime: requestRes.elapsedTime
   };
+}
+
+function createFetchKey(url, opts) {
+  var id = url;
+  if (Object.keys(opts).length > 0) {
+    id += JSON.stringify(opts);
+  }
+
+  return id;
 }
 
 Client.prototype._log = function (res) {
@@ -147,7 +157,29 @@ Client.prototype._request = function (method, url, opts, cb) {
   });
 };
 
-Client.prototype.getWithResponse = function (url, opts, cb) {
+Client.prototype.getWithResponse = function (url, opts, cb ){
+    var client = this;
+    if (!this.sharedExecutionCallbacks){
+        this._getWithResponse(url, opts, cb);
+    } else {
+        var fetchKey = createFetchKey(url, opts);
+        if (!this.sharedExecutionCallbacks[fetchKey]){
+            var handler = function(err, body, res){
+                var cbs = client.sharedExecutionCallbacks[fetchKey];
+                delete client.sharedExecutionCallbacks[fetchKey];
+                for (var i = 0; i < cbs.length; i++){
+                    cbs[i](err, body, res);
+                }
+            };
+            this.sharedExecutionCallbacks[fetchKey] = [ cb ];
+            this._getWithResponse(url, opts, handler);
+        } else {
+            this.sharedExecutionCallbacks[fetchKey].push(cb);
+        }
+    }
+};
+
+Client.prototype._getWithResponse = function (url, opts, cb) {
   this._requestWithCircuitBreaker(GET, url, opts, function (err, body, res) {
     cb(err, body, res);
   });
@@ -206,9 +238,7 @@ Client.prototype.get = function (url, opts, cb) {
     opts = {};
   }
 
-  this._requestWithCircuitBreaker(GET, url, opts, function (err, body, res) {
-    cb(err, body, res);
-  });
+  this.getWithResponse(url, opts, cb);
 };
 
 Client.prototype.post = function (url, requestBody, opts, cb) {

--- a/test/caching.js
+++ b/test/caching.js
@@ -73,60 +73,6 @@ describe('Caching', function () {
     });
   });
 
-
-  it('protects downstream services from the thundering herd problem by sharing execution of multiple concurrent requests for the same resource if enabled', function (done) {
-      var callCount = 0;
-      var inflightRequests = 3;
-      var countdownLatch = inflightRequests;
-      nock.cleanAll();
-      api.get('/').reply(function(uri, body, cb) {
-          callCount = callCount + 1;
-          setTimeout(function() {
-              cb(null, [200, responseBody, headers]);
-          }, 0);
-      });
-      var countDown = function () {
-          countdownLatch = countdownLatch - 1;
-          if (countdownLatch === 0){
-              assert.equal(callCount, 1);
-              done();
-          }
-      };
-      client = Client.createClient({
-          cache: catbox,
-          stats: stats,
-          logger: logger,
-          retries: 0,
-          sharedExecution : true
-      });
-      for (var i = 0; i < inflightRequests; i++){
-          client.get(url, countDown);
-      }
-  });
-
-  it('performs multiple concurrent requests to the same resource if shared execution is not enabled', function (done) {
-      var callCount = 0;
-      var inflightRequests = 3;
-      var countdownLatch = inflightRequests;
-      nock.cleanAll();
-      api.get('/').reply(function(uri, body, cb) {
-          callCount = callCount + 1;
-          setTimeout(function() {
-              cb(null, [200, responseBody, headers]);
-          }, 0);
-      });
-      var countDown = function () {
-          countdownLatch = countdownLatch - 1;
-          if (countdownLatch === 0){
-              assert.equal(callCount, 3);
-              done();
-          }
-      };
-      for (var i = 0; i < inflightRequests; i++){
-          client.get(url, countDown);
-      }
-  });
-
   it('returns the response from the cache if it exists', function (done) {
     var cachedResponseBody = {
       foo: 'baz'

--- a/test/client.js
+++ b/test/client.js
@@ -489,7 +489,7 @@ describe('Rest Client', function () {
       });
     });
 
-    it('protects downstream services from the thundering herd problem by sharing execution of multiple concurrent requests for the same resource if enabled', function (done) {
+    it('shares execution of multiple concurrent requests for the same resource if enabled', function (done) {
         var callCount = 0;
         var inflightRequests = 3;
         var countdownLatch = inflightRequests;

--- a/test/client.js
+++ b/test/client.js
@@ -489,7 +489,7 @@ describe('Rest Client', function () {
       });
     });
 
-    it('shares execution of multiple concurrent requests for the same resource if enabled', function (done) {
+    var sharedExecutionTest = function(client, expectedCallCount, done){
         var callCount = 0;
         var inflightRequests = 3;
         var countdownLatch = inflightRequests;
@@ -503,44 +503,43 @@ describe('Rest Client', function () {
         var countDown = function () {
             countdownLatch = countdownLatch - 1;
             if (countdownLatch === 0){
-                assert.equal(callCount, 1);
+                assert.equal(callCount, expectedCallCount);
                 done();
             }
         };
-        client = Client.createClient({
+        for (var i = 0; i < inflightRequests; i++){
+            client.get(url, countDown);
+        }
+    };
+
+    it('shares execution of multiple concurrent requests for the same resource if enabled', function (done) {
+        var client = Client.createClient({
             logger: logger,
             retries: 0,
             sharedExecution : true
         });
-        for (var i = 0; i < inflightRequests; i++){
-            client.get(url, countDown);
-        }
+        sharedExecutionTest(client, 1, done);
+
     });
       
     it('performs multiple concurrent requests to the same resource if shared execution is not enabled', function (done) {
-        var callCount = 0;
-        var inflightRequests = 3;
-        var countdownLatch = inflightRequests;
-        nock.cleanAll();
-        api.get('/').reply(function(uri, body, cb) {
-            callCount = callCount + 1;
-            setTimeout(function() {
-                cb(null, [200, responseBody]);
-            }, 0);
+        var client = Client.createClient({
+            logger: logger,
+            retries: 0,
+            sharedExecution : false
         });
-        var countDown = function () {
-            countdownLatch = countdownLatch - 1;
-            if (countdownLatch === 0){
-                assert.equal(callCount, 3);
-                done();
-            }
-        };
-        for (var i = 0; i < inflightRequests; i++){
-            client.get(url, countDown);
-        }
-      });
-  });
+        sharedExecutionTest(client, 3, done);
+    });
 
+    it('defaults to performing multiple concurrent requests to the same resource if shared execution is specified', function (done) {
+        var client = Client.createClient({
+            logger: logger,
+            retries: 0
+        });
+        sharedExecutionTest(client, 3, done);
+    });
+  });
+    
   describe('.put', function () {
     it('makes a PUT request with a JSON body', function (done) {
       api.put(path, requestBody).reply(201, responseBody);

--- a/test/client.js
+++ b/test/client.js
@@ -488,6 +488,57 @@ describe('Rest Client', function () {
         done();
       });
     });
+
+    it('protects downstream services from the thundering herd problem by sharing execution of multiple concurrent requests for the same resource if enabled', function (done) {
+        var callCount = 0;
+        var inflightRequests = 3;
+        var countdownLatch = inflightRequests;
+        nock.cleanAll();
+        api.get('/').reply(function(uri, body, cb) {
+            callCount = callCount + 1;
+            setTimeout(function() {
+                cb(null, [200, responseBody]);
+            }, 0);
+        });
+        var countDown = function () {
+            countdownLatch = countdownLatch - 1;
+            if (countdownLatch === 0){
+                assert.equal(callCount, 1);
+                done();
+            }
+        };
+        client = Client.createClient({
+            logger: logger,
+            retries: 0,
+            sharedExecution : true
+        });
+        for (var i = 0; i < inflightRequests; i++){
+            client.get(url, countDown);
+        }
+    });
+      
+    it('performs multiple concurrent requests to the same resource if shared execution is not enabled', function (done) {
+        var callCount = 0;
+        var inflightRequests = 3;
+        var countdownLatch = inflightRequests;
+        nock.cleanAll();
+        api.get('/').reply(function(uri, body, cb) {
+            callCount = callCount + 1;
+            setTimeout(function() {
+                cb(null, [200, responseBody]);
+            }, 0);
+        });
+        var countDown = function () {
+            countdownLatch = countdownLatch - 1;
+            if (countdownLatch === 0){
+                assert.equal(callCount, 3);
+                done();
+            }
+        };
+        for (var i = 0; i < inflightRequests; i++){
+            client.get(url, countDown);
+        }
+      });
   });
 
   describe('.put', function () {

--- a/test/revalidate.js
+++ b/test/revalidate.js
@@ -1,0 +1,117 @@
+var nock = require('nock');
+var assert = require('chai').assert;
+var Client = require('..');
+
+var api = nock('http://www.example.com');
+var url = 'http://www.example.com/';
+
+describe('Caching - revalidation', function () {
+  var client;
+  var stats;
+
+  // a dumb cache with hit counts
+  var simpleCache = {
+      start : function(){
+          this.storage = {};
+          this.cacheHits = 0;
+      },
+      get : function(key, cb){
+          if (this.storage[key])
+              this.cacheHits++;
+          cb( null, { item : this.storage[key] } );
+      },
+      set : function(key, value, ttl, cb){
+          this.storage[key] = value;
+          cb();
+      }
+  };
+
+  var firstResponseBody = 'first';
+  var secondResponseBody = 'second';
+
+  var swrHeaders = {
+      'cache-control': 'max-age=60, stale-while-revalidate=0.001'
+  };
+  var noSwrHeaders = {
+      'cache-control': 'max-age=60'
+  };
+
+  var validate = function (client, resp1, resp2, resp3, cacheHitsCount, refreshCount, done) {
+    client.get(url, function (err, body) {
+      assert.ifError(err);
+      assert.deepEqual(body, resp1);
+    });
+    setTimeout(function(){
+        client.get(url, function (err, body) {
+            assert.ifError(err);
+            assert.deepEqual(body, resp2);
+            
+            setTimeout( function(){
+                client.get(url, function (err, body) {
+                    assert.ifError(err);
+                    assert.deepEqual(body, resp3);
+                    assert.equal(stats.stat['http.cache.refresh'] || 0, refreshCount);
+                    assert.equal(simpleCache.cacheHits, cacheHitsCount);
+                    done();
+                });
+            }, 10);
+        });
+    }, 10);
+  };
+
+  beforeEach(function () {
+      nock.cleanAll();
+      stats = {
+          stat : {},
+          increment: function(key){ 
+              this.stat[key] = (this.stat[key]||0) + 1;
+          },
+          timing : function(){}
+      };
+  });
+
+  it('refreshes cache in the background if stale-while-revalidate is enabled', function (done) {
+      client = Client.createClient({
+          cache: simpleCache,
+          stats : stats,
+          swr : true,
+          retries: 0
+      });            
+      
+      nock.cleanAll();
+      api.get('/').once().reply(200, firstResponseBody, swrHeaders);
+      api.get('/').once().reply(200, secondResponseBody, swrHeaders);
+
+      validate(client, firstResponseBody, firstResponseBody, secondResponseBody, 2, 2, done);
+  });
+
+  it('serves from cache if stale-while-revalidate is in response but disabled', function (done) {
+      client = Client.createClient({
+          stats : stats,
+          cache: simpleCache,
+          swr: false,
+          retries: 0
+      });            
+      
+      nock.cleanAll();
+      api.get('/').once().reply(200, firstResponseBody, swrHeaders);
+      api.get('/').once().reply(200, secondResponseBody, swrHeaders);
+
+      validate(client, firstResponseBody, firstResponseBody, firstResponseBody, 2, 0, done);
+  });
+
+  it('serves from cache if stale-while-revalidate is enabled but missing from response', function (done) {
+      client = Client.createClient({
+          stats : stats,
+          cache: simpleCache,
+          swr: true,
+          retries: 0
+      });            
+      
+      nock.cleanAll();
+      api.get('/').once().reply(200, firstResponseBody, noSwrHeaders);
+      api.get('/').once().reply(200, secondResponseBody, noSwrHeaders);
+
+      validate(client, firstResponseBody, firstResponseBody, firstResponseBody, 2, 0, done);
+  });
+});

--- a/test/revalidate.js
+++ b/test/revalidate.js
@@ -210,10 +210,9 @@ describe('Caching - revalidation', function () {
           client.get(url, function (err, body) {
               assert.deepEqual(body, expected.shift());
               if (expected.length > 0){
-                  unmockedTimeout(function(){
-                      clock.tick(staleTimeout);
+                  runAsyncAfterStaleTimeout(function(){
                       chain(expected);
-                  }, 10);
+                  });
               } else {
                   assert.equal(stats.stat['http.cache.refresh'] || 0, 3);
                   assert.equal(simpleCache.cacheHits, 3);


### PR DESCRIPTION
Hi flashhearteers,
I have had a crack at adding stale while revalidate logic into the caching layer of flashheart to improve the accuracy of its response in the face of different stale-while-revalidate vs max-age values. I have also added the shared execution pattern, which addresses thundering herd upstream request challenges.

I would appreciate a code-review and your thoughts rather then a merge at present. I haven't managed to get jsbeautify applied yet (poor emacs skills...)

Cheers
Paul