### PR TITLE
Add optional support for stale-if-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ const client = require('flashheart').createClient({
 });
 ```
 
+Optionally, you can enable `staleIfError` which will start listening to the `stale-if-error` directive as well. This stores the response for the duration of the `stale-if-error` directive as well as the `max-age` and will try to retrieve them in this order:
+
+* `max-age` stored version
+* fresh version
+* `stale-if-error` version
+
+This is enabled simply by passing in the `staleIfError` parameter to `createClient`:
+
+```js
+const client = require('flashheart').createClient({
+  cache: storage,
+  staleIfError: true
+});
+```
+
 The cache varies on _all_ request options (and therefore, headers) by default. If you don't want to vary on a particular header, use the `doNotVary` option:
 
 ```js

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -22,26 +22,22 @@ function isCacheable(res) {
   return false;
 }
 
-function getMaxAge(res) {
-  var maxAge = -1;
+function getCacheTime(res, directive) {
   var cacheControl = getCacheControl(res);
 
   if (cacheControl) {
-    maxAge = (cacheControl['max-age'] || 0) * 1000;
+    return (cacheControl[directive] || 0) * 1000;
   }
 
-  return maxAge;
+  return -1;
+}
+
+function getMaxAge(res) {
+  return getCacheTime(res, 'max-age');
 }
 
 function getStaleIfError(res) {
-  var staleIfError = -1;
-  var cacheControl = getCacheControl(res);
-
-  if (cacheControl) {
-    staleIfError = (cacheControl['stale-if-error'] || 0) * 1000;
-  }
-
-  return staleIfError;
+  return getCacheTime(res, 'stale-if-error');
 }
 
 function getCacheControl(res) {
@@ -51,7 +47,7 @@ function getCacheControl(res) {
   return wreck.parseCacheControl(cacheControl);
 }
 
-function createKeyObject(url, opts, doNotVary, stale) {
+function createKeyObject(url, opts, doNotVary) {
   var id = url;
   var optsCopy = _.cloneDeep(opts);
 
@@ -69,18 +65,14 @@ function createKeyObject(url, opts, doNotVary, stale) {
     id += JSON.stringify(optsCopy);
   }
 
-  if (stale) {
-    return {
-      id: id,
-      segment: 'flashheart:' + version,
-      stale: true
-    };
-  }
-
   return {
     id: id,
     segment: 'flashheart:' + version
   };
+}
+
+function createStaleKeyObject(url, opts, doNotVary) {
+  return _.extend({}, createKeyObject(url, opts, doNotVary), { stale: true });
 }
 
 CachingClient.prototype.get = function (url, opts, cb) {
@@ -123,13 +115,23 @@ CachingClient.prototype.get = function (url, opts, cb) {
       }
 
       if (client.staleIfError && staleIfError) {
-        cache.set(createKeyObject(url, opts, doNotVary, true), cachedObject, staleIfError, client._handleCacheError.bind(client));
+        cache.set(createStaleKeyObject(url, opts, doNotVary), cachedObject, staleIfError, client._handleCacheError.bind(client));
       }
     }
 
     cb(err, body, res);
   });
 };
+
+function createErrorFromCache(cachedError) {
+  var err = new Error(cachedError.message);
+
+  err.statusCode = cachedError.statusCode;
+  err.body = cachedError.body;
+  err.headers = cachedError.headers;
+
+  return err;
+}
 
 CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   var client = this;
@@ -141,17 +143,12 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
     if (err) client._handleCacheError(err);
 
     var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
-    var cachedError;
 
     if (cacheHit) {
       if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.hits');
 
       if (cached.item.error) {
-        cachedError = cached.item.error;
-        err = new Error(cachedError.message);
-        err.statusCode = cachedError.statusCode;
-        err.body = cachedError.body;
-        err.headers = cachedError.headers;
+        err = createErrorFromCache(cached.item.error);
       }
 
       return cb(err, cached.item.body, cached.item.response, true);
@@ -163,7 +160,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
       if (err && client.staleIfError) {
         var originalErr = err;
 
-        return cache.get(createKeyObject(url, opts, doNotVary, true), function (err, cached) {
+        return cache.get(createStaleKeyObject(url, opts, doNotVary), function (err, cached) {
           if (err) client._handleCacheError(err);
           if (!cached) return cb(originalErr, body, res);
           if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.stale');

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -29,6 +29,17 @@ function getMaxAge(res) {
   return maxAge;
 }
 
+function getStaleIfError(res) {
+  var staleIfError = -1;
+  var cacheControl = getCacheControl(res);
+
+  if (cacheControl) {
+    staleIfError = (cacheControl['stale-if-error'] || 0) * 1000;
+  }
+
+  return staleIfError;
+}
+
 function getCacheControl(res) {
   var cacheControl = res.headers['cache-control'];
   if (!cacheControl) return;
@@ -36,7 +47,7 @@ function getCacheControl(res) {
   return wreck.parseCacheControl(cacheControl);
 }
 
-function createKeyObject(url, opts, doNotVary) {
+function createKeyObject(url, opts, doNotVary, stale) {
   var id = url;
   var optsCopy = _.cloneDeep(opts);
 
@@ -52,6 +63,14 @@ function createKeyObject(url, opts, doNotVary) {
 
   if (Object.keys(optsCopy).length > 0) {
     id += JSON.stringify(optsCopy);
+  }
+
+  if (stale) {
+    return {
+      id: id,
+      segment: 'flashheart:' + version,
+      stale: true
+    }
   }
 
   return {
@@ -73,9 +92,11 @@ CachingClient.prototype.get = function (url, opts, cb) {
   this._getCachedOrFetch(url, opts, function (err, body, res, servedFromCache) {
     var cachedObject;
     var maxAge;
+    var staleIfError;
 
     if (!servedFromCache && res && isCacheable(res)) {
       maxAge = getMaxAge(res);
+      staleIfError = getStaleIfError(res);
       cachedObject = {};
 
       if (body) {
@@ -94,6 +115,7 @@ CachingClient.prototype.get = function (url, opts, cb) {
       }
 
       cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, client._handleCacheError.bind(client));
+      cache.set(createKeyObject(url, opts, doNotVary, true), cachedObject, staleIfError, client._handleCacheError.bind(client));
     }
 
     cb(err, body, res);
@@ -128,7 +150,15 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
 
     if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
 
-    delegate.getWithResponse(url, opts, cb);
+    delegate.getWithResponse(url, opts, function (err, body, res) {
+      if (err) {
+        return cache.get(createKeyObject(url, opts, doNotVary, true), function (err, cached) {
+          cb(err, cached.item.body, cached.item.response, true);
+        });
+      }
+
+      cb(err, body, res);
+    });
   });
 };
 

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -160,12 +160,12 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
     if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
 
     delegate.getWithResponse(url, opts, function (err, body, res) {
-      if (err) {
+      if (err && client.staleIfError) {
         var originalErr = err;
 
         return cache.get(createKeyObject(url, opts, doNotVary, true), function (err, cached) {
           if (err) client._handleCacheError(err);
-          if (!cached) cb(originalErr, body, res);
+          if (!cached) return cb(originalErr, body, res);
           if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.stale');
 
           cb(err, cached.item.body, cached.item.response, true);

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -5,6 +5,7 @@ var version = require('../package').version;
 function CachingClient(delegate, opts) {
   this.delegate = delegate;
   this.cache = opts.cache;
+  this.staleIfError = opts.staleIfError;
   this.doNotVary = opts.doNotVary || [];
 }
 
@@ -12,7 +13,10 @@ function isCacheable(res) {
   var cacheControl = getCacheControl(res);
 
   if (cacheControl) {
-    return !cacheControl['no-cache'] && !cacheControl.private && cacheControl['max-age'] > 0;
+    const hasMaxAge = cacheControl['max-age'] > 0;
+    const hasStaleIfError = cacheControl['stale-if-error'] > 0;
+
+    return !cacheControl['no-cache'] && !cacheControl.private && (hasMaxAge || hasStaleIfError);
   }
 
   return false;
@@ -70,7 +74,7 @@ function createKeyObject(url, opts, doNotVary, stale) {
       id: id,
       segment: 'flashheart:' + version,
       stale: true
-    }
+    };
   }
 
   return {
@@ -114,8 +118,13 @@ CachingClient.prototype.get = function (url, opts, cb) {
         };
       }
 
-      cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, client._handleCacheError.bind(client));
-      cache.set(createKeyObject(url, opts, doNotVary, true), cachedObject, staleIfError, client._handleCacheError.bind(client));
+      if (maxAge) {
+        cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, client._handleCacheError.bind(client));
+      }
+
+      if (client.staleIfError && staleIfError) {
+        cache.set(createKeyObject(url, opts, doNotVary, true), cachedObject, staleIfError, client._handleCacheError.bind(client));
+      }
     }
 
     cb(err, body, res);
@@ -152,7 +161,13 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
 
     delegate.getWithResponse(url, opts, function (err, body, res) {
       if (err) {
+        var originalErr = err;
+
         return cache.get(createKeyObject(url, opts, doNotVary, true), function (err, cached) {
+          if (err) client._handleCacheError(err);
+          if (!cached) cb(originalErr, body, res);
+          if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.stale');
+
           cb(err, cached.item.body, cached.item.response, true);
         });
       }

--- a/test/caching.js
+++ b/test/caching.js
@@ -199,6 +199,28 @@ describe('Caching', function () {
     });
   });
 
+  it('does not read stale cache if staleIfError is not enabled', function (done) {
+    var errorResponseCode = 503;
+    var errorResponseBody = {
+      error: 'An error'
+    };
+    var errorHeaders = {
+      'cache-control': 'max-age=5',
+      'content-type': 'application/json',
+      'www-authenticate': 'Bearer realm="/"'
+    };
+
+    nock.cleanAll();
+    api.get('/').reply(errorResponseCode, errorResponseBody, errorHeaders);
+    client.get(url, function (err) {
+      assert.ok(err);
+      assert.equal(err.statusCode, 503);
+      sinon.assert.calledOnce(catbox.get);
+      sinon.assert.calledWith(catbox.get, expectedKey);
+      done();
+    });
+  });
+
   it('returns an error from the cache if it exists', function (done) {
     var errorResponseBody = {
       error: 'An error'


### PR DESCRIPTION
When we pass in the flag `staleIfError`, the client caches two copies of the response for `max-age` and `stale-if-error` durations if available.

On error it tries `stale-if-error` cache before returning the error.

Enabled in the following way:

```js
const client = require('flashheart').createClient({
  cache: storage,
  staleIfError: true
});
```