### PR TITLE
Bring getStatsName into the Client object fixes #68

### DIFF
--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -144,12 +144,12 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   var doNotVary = this.doNotVary;
 
   cache.get(createKeyObject(url, opts, doNotVary), function (err, cached) {
-    if (err) client._handleCacheError(err);
+    if (err) client._handleCacheError(err, opts);
 
     var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
 
     if (cacheHit) {
-      if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.hits');
+      if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts.name) + '.cache.hits');
 
       if (cached.item.error) {
         err = createErrorFromCache(cached.item.error);
@@ -158,16 +158,16 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
       return cb(err, cached.item.body, cached.item.response, true);
     }
 
-    if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.misses');
+    if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts.name) + '.cache.misses');
 
     delegate.getWithResponse(url, opts, function (err, body, res) {
       if (err && client.staleIfError) {
         var originalErr = err;
 
         return cache.get(createStaleKeyObject(url, opts, doNotVary), function (err, cached) {
-          if (err) client._handleCacheError(err);
+          if (err) client._handleCacheError(err, opts);
           if (!cached || cached.item.error) return cb(originalErr, body, res);
-          if (delegate.stats) delegate.stats.increment(delegate.name + '.cache.stale');
+          if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts.name) + '.cache.stale');
 
           cb(err, cached.item.body, cached.item.response, true);
         });
@@ -178,10 +178,10 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   });
 };
 
-CachingClient.prototype._handleCacheError = function (err) {
+CachingClient.prototype._handleCacheError = function (err, opts) {
   if (err) {
     if (this.delegate.logger) this.delegate.logger.warn('Cache error:', err.message);
-    if (this.delegate.stats) this.delegate.stats.increment(this.delegate.name + '.cache.errors');
+    if (this.delegate.stats) this.delegate.stats.increment(this.delegate.getStatsName(opts.name) + '.cache.errors');
   }
 };
 

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -114,12 +114,18 @@ CachingClient.prototype.get = function (url, opts, cb) {
       }
 
       if (maxAge) {
-        cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, client._handleCacheError.bind(client));
+        // Anonymous function needed here to pass opts through, as cache only calls func(err)
+        cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, function(err) { 
+          client._handleCacheError.call(client, err, opts);
+        });
       }
 
       if (!err && client.staleIfError && staleIfError) {
         var staleExpiry = staleIfError + maxAge;
-        cache.set(createStaleKeyObject(url, opts, doNotVary), cachedObject, staleExpiry, client._handleCacheError.bind(client));
+        // Anonymous function needed here to pass opts through, as cache only calls func(err)
+        cache.set(createStaleKeyObject(url, opts, doNotVary), cachedObject, staleExpiry, function(err) { 
+          client._handleCacheError.call(client, err, opts);
+        });
       }
     }
 
@@ -142,6 +148,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
   var cache = this.cache;
   var delegate = this.delegate;
   var doNotVary = this.doNotVary;
+
 
   cache.get(createKeyObject(url, opts, doNotVary), function (err, cached) {
     if (err) client._handleCacheError(err, opts);

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -149,7 +149,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
     var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
 
     if (cacheHit) {
-      if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts.name) + '.cache.hits');
+      if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts) + '.cache.hits');
 
       if (cached.item.error) {
         err = createErrorFromCache(cached.item.error);
@@ -158,7 +158,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
       return cb(err, cached.item.body, cached.item.response, true);
     }
 
-    if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts.name) + '.cache.misses');
+    if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts) + '.cache.misses');
 
     delegate.getWithResponse(url, opts, function (err, body, res) {
       if (err && client.staleIfError) {
@@ -167,7 +167,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
         return cache.get(createStaleKeyObject(url, opts, doNotVary), function (err, cached) {
           if (err) client._handleCacheError(err, opts);
           if (!cached || cached.item.error) return cb(originalErr, body, res);
-          if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts.name) + '.cache.stale');
+          if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts) + '.cache.stale');
 
           cb(err, cached.item.body, cached.item.response, true);
         });
@@ -181,7 +181,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
 CachingClient.prototype._handleCacheError = function (err, opts) {
   if (err) {
     if (this.delegate.logger) this.delegate.logger.warn('Cache error:', err.message);
-    if (this.delegate.stats) this.delegate.stats.increment(this.delegate.getStatsName(opts.name) + '.cache.errors');
+    if (this.delegate.stats) this.delegate.stats.increment(this.delegate.getStatsName(opts) + '.cache.errors');
   }
 };
 

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -149,7 +149,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
     var cacheHit = cached && cached.item && (cached.item.body || cached.item.error);
 
     if (cacheHit) {
-      if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts) + '.cache.hits');
+      if (delegate.stats) delegate.stats.increment(delegate._getStatsName(opts) + '.cache.hits');
 
       if (cached.item.error) {
         err = createErrorFromCache(cached.item.error);
@@ -158,7 +158,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
       return cb(err, cached.item.body, cached.item.response, true);
     }
 
-    if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts) + '.cache.misses');
+    if (delegate.stats) delegate.stats.increment(delegate._getStatsName(opts) + '.cache.misses');
 
     delegate.getWithResponse(url, opts, function (err, body, res) {
       if (err && client.staleIfError) {
@@ -167,7 +167,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
         return cache.get(createStaleKeyObject(url, opts, doNotVary), function (err, cached) {
           if (err) client._handleCacheError(err, opts);
           if (!cached || cached.item.error) return cb(originalErr, body, res);
-          if (delegate.stats) delegate.stats.increment(delegate.getStatsName(opts) + '.cache.stale');
+          if (delegate.stats) delegate.stats.increment(delegate._getStatsName(opts) + '.cache.stale');
 
           cb(err, cached.item.body, cached.item.response, true);
         });
@@ -181,7 +181,7 @@ CachingClient.prototype._getCachedOrFetch = function (url, opts, cb) {
 CachingClient.prototype._handleCacheError = function (err, opts) {
   if (err) {
     if (this.delegate.logger) this.delegate.logger.warn('Cache error:', err.message);
-    if (this.delegate.stats) this.delegate.stats.increment(this.delegate.getStatsName(opts) + '.cache.errors');
+    if (this.delegate.stats) this.delegate.stats.increment(this.delegate._getStatsName(opts) + '.cache.errors');
   }
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -107,7 +107,7 @@ Client.prototype._log = function (res) {
   }
 };
 
-Client.prototype.getStatsName = function (opts) {
+Client.prototype._getStatsName = function (opts) {
   if (opts && 'name' in opts) {
     return this.name + '.' + opts.name;
   }
@@ -119,7 +119,7 @@ Client.prototype._recordStats = function (res, opts) {
   var statsName;
 
   if (this.stats) {
-    statsName = this.getStatsName(opts);
+    statsName = this._getStatsName(opts);
     this.stats.increment(statsName + '.requests');
     this.stats.increment(statsName + '.responses.' + res.statusCode);
     this.stats.timing(statsName + '.response_time', res.elapsedTime);
@@ -140,7 +140,7 @@ Client.prototype._request = function (method, url, opts, cb) {
 
     if (err) {
       if (client.stats) {
-        statsName = client.getStatsName(opts);
+        statsName = client._getStatsName(opts);
         client.stats.increment(statsName + '.request_errors');
       }
       err = new Error(util.format('Request failed for %s %s', buildUrl(url, opts), err.message));
@@ -194,7 +194,7 @@ Client.prototype._requestWithRetries = function (method, url, opts, cb) {
       }
 
       if (client.stats) {
-        statsName = client.getStatsName(opts);
+        statsName = client._getStatsName(opts);
         client.stats.timing(statsName + '.attempts', currentAttempts);
       }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -82,14 +82,6 @@ function isCriticalError(err) {
   return true;
 }
 
-function getStatsName(clientName, feedName) {
-  if (feedName) {
-    return clientName + '.' + feedName;
-  }
-
-  return clientName;
-}
-
 function buildResponse(requestRes) {
   return {
     statusCode: requestRes.statusCode,
@@ -115,11 +107,19 @@ Client.prototype._log = function (res) {
   }
 };
 
+Client.prototype.getStatsName = function (feedName) {
+  if (feedName) {
+    return this.name + '.' + feedName;
+  }
+
+  return this.name;
+};
+
 Client.prototype._recordStats = function (res, feedName) {
   var statsName;
 
   if (this.stats) {
-    statsName = getStatsName(this.name, feedName);
+    statsName = this.getStatsName(feedName);
     this.stats.increment(statsName + '.requests');
     this.stats.increment(statsName + '.responses.' + res.statusCode);
     this.stats.timing(statsName + '.response_time', res.elapsedTime);
@@ -140,7 +140,7 @@ Client.prototype._request = function (method, url, opts, cb) {
 
     if (err) {
       if (client.stats) {
-        statsName = getStatsName(client.name, opts.name);
+        statsName = client.getStatsName(opts.name);
         client.stats.increment(statsName + '.request_errors');
       }
       err = new Error(util.format('Request failed for %s %s', buildUrl(url, opts), err.message));
@@ -194,7 +194,7 @@ Client.prototype._requestWithRetries = function (method, url, opts, cb) {
       }
 
       if (client.stats) {
-        statsName = getStatsName(client.name, opts.name);
+        statsName = client.getStatsName(opts.name);
         client.stats.timing(statsName + '.attempts', currentAttempts);
       }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -107,19 +107,19 @@ Client.prototype._log = function (res) {
   }
 };
 
-Client.prototype.getStatsName = function (feedName) {
-  if (feedName) {
-    return this.name + '.' + feedName;
+Client.prototype.getStatsName = function (opts) {
+  if (opts && 'name' in opts) {
+    return this.name + '.' + opts.name;
   }
 
   return this.name;
 };
 
-Client.prototype._recordStats = function (res, feedName) {
+Client.prototype._recordStats = function (res, opts) {
   var statsName;
 
   if (this.stats) {
-    statsName = this.getStatsName(feedName);
+    statsName = this.getStatsName(opts);
     this.stats.increment(statsName + '.requests');
     this.stats.increment(statsName + '.responses.' + res.statusCode);
     this.stats.timing(statsName + '.response_time', res.elapsedTime);
@@ -140,7 +140,7 @@ Client.prototype._request = function (method, url, opts, cb) {
 
     if (err) {
       if (client.stats) {
-        statsName = client.getStatsName(opts.name);
+        statsName = client.getStatsName(opts);
         client.stats.increment(statsName + '.request_errors');
       }
       err = new Error(util.format('Request failed for %s %s', buildUrl(url, opts), err.message));
@@ -151,7 +151,7 @@ Client.prototype._request = function (method, url, opts, cb) {
     var res = buildResponse(requestRes);
 
     client._log(requestRes);
-    client._recordStats(requestRes, opts.name);
+    client._recordStats(requestRes, opts);
 
     if (requestRes.statusCode >= 400) {
       err = new Error(util.format('Received HTTP code %d for %s %s', requestRes.statusCode, requestRes.request.method, requestRes.request.href));
@@ -194,7 +194,7 @@ Client.prototype._requestWithRetries = function (method, url, opts, cb) {
       }
 
       if (client.stats) {
-        statsName = client.getStatsName(opts.name);
+        statsName = client.getStatsName(opts);
         client.stats.timing(statsName + '.attempts', currentAttempts);
       }
 

--- a/test/caching.js
+++ b/test/caching.js
@@ -303,6 +303,24 @@ describe('Caching', function () {
     });
   });
 
+  it('Uses the request name when incrementing the counter', function (done) {
+    client.get(url, {name: 'sheeba'}, function (err) {
+      assert.ifError(err);
+      sinon.assert.calledWith(stats.increment, 'http.sheeba.requests'); 
+      sinon.assert.calledWith(stats.increment, 'http.sheeba.responses.200');
+      done();
+    });
+  });
+
+  it('Uses the request name when incrementing the counter (when the cache fails)', function (done) {
+    catbox.set.yields(new Error('Good use of Sheeba!'));
+    client.get(url, {name: 'sheeba'}, function (err) {
+      assert.ifError(err);
+      sinon.assert.calledWith(stats.increment, 'http.sheeba.cache.errors');
+      done();
+    });
+  });
+
   it('returns the response when writing to the cache fails', function (done) {
     catbox.set.withArgs(expectedKey).returns(new Error('Good use of Sheeba!'));
     client.get(url, function (err, body) {

--- a/test/client.js
+++ b/test/client.js
@@ -270,7 +270,7 @@ describe('Rest Client', function () {
     });
 
     it('calls _getStatsName when incrementing', function (done) {
-      let spy = sinon.spy(client, '_getStatsName');
+      var spy = sinon.spy(client, '_getStatsName');
       nock.cleanAll();
       client.get(url, function (err) {
         assert(err);

--- a/test/client.js
+++ b/test/client.js
@@ -269,6 +269,16 @@ describe('Rest Client', function () {
       });
     });
 
+    it('calls _getStatsName when incrementing', function (done) {
+      let spy = sinon.spy(client, '_getStatsName');
+      nock.cleanAll();
+      client.get(url, function (err) {
+        assert(err);
+        sinon.assert.called(spy);
+        done();
+      });
+    });
+
     it('increments a counter for errors with feed name in it', function (done) {
       var client = Client.createClient({
         name: 'my_client',


### PR DESCRIPTION
Before fix
```
http.cache.misses
GET https://navigation.api.bbci.co.uk/api 200 147 ms
http.Orbit.requests
http.Orbit.responses.200
http.Orbit.response_time 147
http.Orbit.attempts 1
http.cache.misses
GET https://radio-nav-service.api.bbci.co.uk/radio-nav-service/json 200 414 ms
http.RadioNavService.requests
http.RadioNavService.responses.200
http.RadioNavService.response_time 414
http.RadioNavService.attempts 1
http.cache.hits
http.cache.hits

```

After fix

```
http.Orbit.cache.misses
GET https://navigation.api.bbci.co.uk/api 200 298 ms
http.Orbit.requests
http.Orbit.responses.200
http.Orbit.response_time 298
http.Orbit.attempts 1
http.RadioNavService.cache.misses
GET https://radio-nav-service.api.bbci.co.uk/radio-nav-service/json 200 756 ms
http.RadioNavService.requests
http.RadioNavService.responses.200
http.RadioNavService.response_time 756
http.RadioNavService.attempts 1
http.Orbit.cache.hits
http.RadioNavService.cache.hits
```

This fixes #68 