### PR TITLE
Allow client to be created asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ const client = require('flashheart').createClient({
 });
 ```
 
+If using a Redis client, you may need to allow the client time to connect to your Redis instance before attempting to request. For this reason, you can create the client asynchronously and return a promise which you can resolve with the connected client:
+
+```js
+const clientPromise = require('flashheart').createClientAsync({
+  cache: storage
+});
+
+clientPromise.then(function(client) {
+  client.get(url);
+})
+```
+
 ### Logging
 
 All requests can be logged at `info` level if you provide a logger that supports the standard logging API (like `console` or [Winston](https://github.com/flatiron/winston))

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Client = require('./lib/client');
 var CachingClient = require('./lib/cachingClient');
+var Promise = require('bluebird');
 var _ = require('lodash');
 
 module.exports.createClient = function (opts) {
@@ -12,6 +13,24 @@ module.exports.createClient = function (opts) {
   }
 
   return client;
+};
+
+module.exports.createClientAsync = function (opts) {
+  opts = opts || {};
+  var client = new Client(opts);
+
+  if (!_.isUndefined(opts.cache)) {
+
+    var start = Promise.promisify(opts.cache.start, { context: opts.cache });
+
+    return start().then(function() {
+      return new CachingClient(client, opts);
+    });
+  }
+
+  return new Promise(function(resolve) {
+    resolve(client);
+  });
 };
 
 module.exports.Client = Client;

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -116,10 +116,6 @@ CachingClient.prototype.get = function (url, opts, cb) {
       if (maxAge) {
         // Anonymous function needed here to pass opts through, as cache only calls func(err)
         cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, function(err) { 
-          // console.log('!!!!!!!!! KEY')
-          // console.log(createKeyObject(url, opts, doNotVary));
-          // console.log('!!!!!!!!! BODY');
-          // console.log(cachedObject);
           client._handleCacheError.call(client, err, opts);
         });
       }

--- a/lib/cachingClient.js
+++ b/lib/cachingClient.js
@@ -116,6 +116,10 @@ CachingClient.prototype.get = function (url, opts, cb) {
       if (maxAge) {
         // Anonymous function needed here to pass opts through, as cache only calls func(err)
         cache.set(createKeyObject(url, opts, doNotVary), cachedObject, maxAge, function(err) { 
+          // console.log('!!!!!!!!! KEY')
+          // console.log(createKeyObject(url, opts, doNotVary));
+          // console.log('!!!!!!!!! BODY');
+          // console.log(cachedObject);
           client._handleCacheError.call(client, err, opts);
         });
       }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     }
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "debug": "^2.2.0",
     "levee": "^1.2.0",
     "lodash": "^4.2.0",

--- a/test/caching.js
+++ b/test/caching.js
@@ -106,7 +106,6 @@ describe('Caching', function () {
         done();
       });
     });
-
   });
 
   it('caches the stale value if stale-if-error is set', function (done) {

--- a/test/caching.js
+++ b/test/caching.js
@@ -27,6 +27,7 @@ describe('Caching', function () {
   var logger;
   var client;
   var staleClient;
+  var clientPromise;
   var catbox;
 
   var headers = {
@@ -49,7 +50,9 @@ describe('Caching', function () {
     catbox = {
       set: sandbox.stub(),
       get: sandbox.stub(),
-      start: sandbox.stub()
+      start: function(callback) {
+        callback();
+      }
     };
     stats = {
       increment: sandbox.stub(),
@@ -73,6 +76,12 @@ describe('Caching', function () {
       retries: 0,
       staleIfError: true
     });
+    clientPromise = Client.createClientAsync({
+      cache: catbox,
+      stats: stats,
+      logger: logger,
+      retries: 0
+    });
   });
 
   it('caches the body and the response based on its max-age header', function (done) {
@@ -84,6 +93,20 @@ describe('Caching', function () {
       }, 60000);
       done();
     });
+  });
+
+  it('caches the body and the response using the async client', function (done) {
+    clientPromise.then(function(client) {
+      client.get(url, function (err) {
+        assert.ifError(err);
+        sinon.assert.calledWith(catbox.set, expectedKey, {
+          body: responseBody,
+          response: expectedCachedResponse
+        }, 60000);
+        done();
+      });
+    });
+
   });
 
   it('caches the stale value if stale-if-error is set', function (done) {

--- a/test/client.js
+++ b/test/client.js
@@ -111,6 +111,14 @@ describe('Rest Client', function () {
     });
   });
 
+  it('can be created aynscronously without cache', function () {
+    var clientPromise = Client.createClientAsync();
+
+    return clientPromise.then(() => {
+      assert.ok(client);  
+    });
+  });
+
   describe('.get', function () {
     it('returns body of a JSON response', function (done) {
       client.get(url, function (err, body) {

--- a/test/client.js
+++ b/test/client.js
@@ -114,7 +114,7 @@ describe('Rest Client', function () {
   it('can be created asynschronously without cache', function () {
     var clientPromise = Client.createClientAsync();
 
-    return clientPromise.then(() => {
+    return clientPromise.then(function () {
       assert.ok(client);  
     });
   });

--- a/test/client.js
+++ b/test/client.js
@@ -111,7 +111,7 @@ describe('Rest Client', function () {
     });
   });
 
-  it('can be created aynscronously without cache', function () {
+  it('can be created asynschronously without cache', function () {
     var clientPromise = Client.createClientAsync();
 
     return clientPromise.then(() => {


### PR DESCRIPTION
As outlined in https://github.com/bbc/flashheart/issues/72 - sometimes we need to allow the client to connect to a Redis instance before attempting to make a request. For this reason a `createClientAsync` function is useful.