### PR TITLE
Allow client to be created asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ const client = require('flashheart').createClient({
 });
 ```
 
+When using a cache client that connects to a Redis instance, it is sometimes required to ensure the connection to the Redis instance has completed before making a request. To ensure this is the case, you can create the client asynchronously:
+
+```js
+const client = require('flashheart').createClientAsync({
+  cache: storage
+}, function(error, client) {
+  // Check for errors and use the client as needed
+});
+```
+
 ### Logging
 
 All requests can be logged at `info` level if you provide a logger that supports the standard logging API (like `console` or [Winston](https://github.com/flatiron/winston))

--- a/index.js
+++ b/index.js
@@ -14,4 +14,19 @@ module.exports.createClient = function (opts) {
   return client;
 };
 
+module.exports.createClientAsync = function (opts, callback) {
+  opts = opts || {};
+  var client = new Client(opts);
+  var error = null;
+
+  if (!_.isUndefined(opts.cache)) {
+    opts.cache.start(function(err) {
+      client = new CachingClient(client, opts);
+      error = err;
+    });
+  }
+
+  return callback(error, client);
+};
+
 module.exports.Client = Client;

--- a/test/caching.js
+++ b/test/caching.js
@@ -60,6 +60,7 @@ describe('Caching', function () {
       warn: sandbox.stub()
     };
     catbox.get.yields(null);
+    catbox.start.yields(null);
     client = Client.createClient({
       cache: catbox,
       stats: stats,
@@ -82,6 +83,37 @@ describe('Caching', function () {
         body: responseBody,
         response: expectedCachedResponse
       }, 60000);
+      done();
+    });
+  });
+
+  it('caches the body and the response using client created asynchronously', function (done) {
+    Client.createClientAsync({
+      cache: catbox,
+      stats: stats,
+      logger: logger,
+      retries: 0
+    }, function(err, client) {
+      client.get(url, function (err) {
+        assert.ifError(err);
+        sinon.assert.calledWith(catbox.set, expectedKey, {
+          body: responseBody,
+          response: expectedCachedResponse
+        }, 60000);
+        done();
+      });
+    });
+  });
+
+  it('passes error back if starting the cache fails when creating aysnchronously', function(done) {
+    catbox.start.yields(new Error('An error'));
+    Client.createClientAsync({
+      cache: catbox,
+      stats: stats,
+      logger: logger,
+      retries: 0
+    }, function(err) {
+      assert.ok(err);
       done();
     });
   });

--- a/test/client.js
+++ b/test/client.js
@@ -58,6 +58,14 @@ describe('Rest Client', function () {
     assert.ok(client);
   });
 
+  it('can be created asynchronously without any options', function (done) {
+    Client.createClientAsync(null , function(err, client) {
+      assert.ifError(err);
+      assert.ok(client);
+      done();      
+    });
+  });
+
   it('can append default options to the existing request client', function (done) {
     var client = Client.createClient({
       defaults: {


### PR DESCRIPTION
As outlined in #72 - sometimes we need to allow the client to connect to a Redis instance before attempting to make a request. For this reason a createClientAsync function is useful.

This is a callback version of the other PR I raised.