### PR TITLE
Allow how linear/non-linear the backoff is to be controlled

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,16 +154,27 @@ You can also add the `name` option on a per-request basis which will include the
 
 ### Retries
 
-By default the client retries failed requests once, with a delay of 100 milliseconds between attempts. The number of times to retry and the delay between retries can be configured using the `retries` and `retryTimeout` properties.
+By default the client retries failed requests once, with a delay of 100 milliseconds between attempts. The number of times to retry and the delay between retries can be configured using the `retries`, `retryTimeout`, and `backoffFactor` properties.
 
-For example, to retry 10 times, with a delay of 500ms:
+`backoffFactor` can be used to make the time between attempt non-linear. It's used in concert with the `retryTimeout`
+and the attempt number (starting at 0) like so: `delay = retryTimeout * 2^retryNumber`.
+
+For example, to retry twice, with a delay of 100ms, and exponential backoff:
 
 ```js
 const client = require('flashheart').createClient({
-  retries: 10,
-  retryTimeout: 500
+  retries: 3,
+  retryTimeout: 100,
+  backoffFactor: 2,
 });
 ```
+
+This would result in the following delays between retries:
+* attempt 0: 100ms * 2^0 == 100ms
+* attempt 1: 100ms * 2^1 == 200ms
+* attempt 2: 100ms * 2^2 == 400ms
+
+
 
 Default retries can be overridden using method options:
 ```js

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,6 +20,7 @@ const DEFAULT_RETRIES = 1;
 const DEFAULT_RETRY_TIMEOUT = 100;
 const DEFAULT_RATE_LIMIT_LIMIT = Number.POSITIVE_INFINITY;
 const DEFAULT_RATE_LIMIT_INTERVAL = 0;
+const DEFAULT_BACKOFF_FACTOR = 2;
 const DEFAULT_CIRCUIT_BREAKER_FAILURES = 100;
 const DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT = 10000;
 const DEFAULT_CIRCUIT_BREAKER_TIMEOUT = 0x7FFFFFFF; // Set high to effectively disable the circuit breaker timeout
@@ -44,6 +45,7 @@ function Client(opts) {
   this.timeout = _.isUndefined(opts.timeout) ? DEFAULT_TIMEOUT : opts.timeout;
   this.retries = _.isUndefined(opts.retries) ? DEFAULT_RETRIES : opts.retries;
   this.retryTimeout = _.isUndefined(opts.retryTimeout) ? DEFAULT_RETRY_TIMEOUT : opts.retryTimeout;
+  this.backoffFactor = _.isUndefined(opts.backoffFactor) ? DEFAULT_BACKOFF_FACTOR : opts.backoffFactor;
   this.userAgent = _.isUndefined(opts.userAgent) ? util.format('%s/%s', package.name, package.version) : opts.userAgent;
 
   var rateLimitLimit = _.isUndefined(opts.rateLimitLimit) ? DEFAULT_RATE_LIMIT_LIMIT : opts.rateLimitLimit;
@@ -176,10 +178,11 @@ Client.prototype._requestWithRetries = function (method, url, opts, cb) {
 
   var timeout = _.isUndefined(opts.retryTimeout) ? this.retryTimeout : opts.retryTimeout;
   var retries = _.isUndefined(opts.retries) ? this.retries : opts.retries;
+  var factor  = _.isUndefined(opts.backoffFactor) ? this.backoffFactor : opts.backoffFactor;
   var operation = retry.operation({
     retries: retries,
     minTimeout: timeout,
-    maxTimeout: timeout
+    factor: factor
   });
 
   operation.attempt(function (currentAttempts) {


### PR DESCRIPTION
We (Autopilot) needed control the backoff factor and allow for values other than
the default of 2. I'm not sure whether this is  useful upstream behaviour but 
I figured it's worth a PR to see. 

This PR adds a new option called `backoffFactor`, which defaults to 2, that is 
passed to `retry.operation` as the `factor` option. `factor` represents the 
exponential factor that retry will use.

Previously, the code was not passing anything through which means that it was
getting the `retry` package's default value of 2 (i.e. exponential). But as
the min and max timeouts were set to the same value it was kind of short
circuiting exponential part of backoff.

### Backward compatibility

This changes the default behaviour to be different than before. This may be
a problem. This could be addressed by changing the default for `backoffFactor`
to 1. Alternatively, a `maxRetryTimeout` option could be added, which could
default to the same value as `retryTimeout`, and feed into the `maxTimeout` 
option of retry.

E.g. accepting all the defaults suggested above would result in a call
to `retry.operation` like:

``` js
var operation = retry.operation({
  retries: retries,
  minTimeout: {{the value of retryTimeout}},
  maxTimeout: {{the value of maxRetryTimeout; defaulting to retryTimeout}},
  factor: {{defaults to 2}},
});
```

Which should preserve all the existing behaviour. If any of the above sounds sensible I'm happy to make those changes as well :-)