### PR TITLE
Update request to 2.83.0 to remove deprecated node-uuid module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "flashheart",
   "version": "2.9.0",
-  "description":
-    "A fully-featured REST client built for ease-of-use and resilience",
+  "description": "A fully-featured REST client built for ease-of-use and resilience",
   "main": "index.js",
   "scripts": {
     "test": "mocha",
@@ -59,7 +58,7 @@
     "debug": "^2.2.0",
     "levee": "^1.2.0",
     "lodash": "^4.2.0",
-    "request": "2.78.0",
+    "request": "^2.83.0",
     "retry": "^0.10.0",
     "simple-rate-limiter": "^0.2.3",
     "wreck": "^5.6.0"


### PR DESCRIPTION
node-uuid is deprecated, and has been replaced by uuid

The request library took this change in Apr 2016: https://github.com/request/request/commit/263e16ec89edb8041657edb9280d9b0039146845